### PR TITLE
(fix): handle non-existent key in storage

### DIFF
--- a/persist.js
+++ b/persist.js
@@ -30,6 +30,8 @@ export const persist = (name, store, options = {}) => {
   return storage.getItem(name)
     .then((data) => {
       const snapshot = !jsonify ? data : JSON.parse(data)
+      // don't apply falsey (which will error), leave store in initial state
+      if (!snapshot) { return }
       applySnapshot(store, snapshot)
     })
 }


### PR DESCRIPTION
- if key is falsey, i.e. when storage has been cleared or has yet to
  be set to initial state, applySnapshot will fail and throw an error
  - so don't apply it if falsey, just skip the applySnapshot call
    - was thinking of applying `{}`, an empty object, if falsey, but
      this will reset the initial state of the store to its defaults
      - one might set initial state in `create({ ... })`, so that
        alternative doesn't work
    - getting the initial snapshot and setting it to itself was another
      alternative considered, but that would be quite complex with
      unnecessary operations, and might cause some unintended behavior
      due to whitelists, blacklists, etc applying
      - still need to think about the ramifications of those since
        applySnapshot doesn't merge, it just sets (and defaults are
        applied on top)
    - see also #1

resolves #1 .

I should probably add some tests before merging this in, though it's a one-liner skip, so it obviously works