### PR TITLE
enable server side rendering

### DIFF
--- a/persist.js
+++ b/persist.js
@@ -5,7 +5,11 @@ import * as LocalStorage from './localStorageAdaptor.js'
 export const persist = (name, store, options = {}) => {
   let {storage, jsonify, whitelist, blacklist} = options
 
-  if (typeof window.localStorage !== 'undefined' && (!storage || storage === window.localStorage)) {
+  if (
+  	typeof window !== 'undefined'
+  	&& typeof window.localStorage !== 'undefined'
+  	&& (!storage || storage === window.localStorage)
+  ) {
     storage = LocalStorage
   }
   if (!jsonify) { jsonify = true } // default to true like mobx-persist


### PR DESCRIPTION
I use GatsbyJS in my App. Which means that as soon as mst-persist is imported, the gatsby project can not be built any more: the build errors `window is not defined`.

So I now have to use mst-persist like this:
```js
  if (typeof window !== 'undefined') {
    import('mst-persist').then(module =>
      module
        .default('store', store, {
          storage: localForage,
          jsonify: false,
        })
        .then(() => {
          console.log('store has been hydrated')
          // navigate to last activeNodeArray
          store.tree.setActiveNodeArray(store.tree.activeNodeArray)
        }),
    )
  }
```

Thus it is much easier if `if (typeof window !== 'undefined')` is done in mst-persist itself.