### PR TITLE
(feat): support SSR out-of-the-box by no-op'ing in Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,16 @@ persist('some', someStore, {
     - **jsonify** *bool* Enables serialization as JSON (default: `true`).
     - **whitelist** *Array\<string\>* Only these keys will be persisted (defaults to all keys).
     - **blacklist** *Array\<string\>* These keys will not be persisted (defaults to all keys).
+    - **nodeNoop** *bool* Whether this should no-op in a Node environment (default: `true`). See below for more details.
 
 - returns a void Promise
+
+### Node and SSR Usage
+
+To support Server-Side Rendering (SSR) out-of-the-box, `persist` will no-op in a Node environment by default.<br>
+Please note that it uses `typeof window === 'undefined'` to check. [`window` is defined in React Native](https://stackoverflow.com/questions/49911424/what-does-the-variable-window-represent-in-react-native), but may not be in test runners and other simulated environments.
+
+If you'd like to hydrate your store in Node (vs. in the browser, which is the standard usage), set `nodeNoop` to `false` and `storage` to a supported provider for Node.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ persist('some', someStore, {
 ### Node and SSR Usage
 
 To support Server-Side Rendering (SSR) out-of-the-box, `persist` will no-op in a Node environment by default.<br>
-Please note that it uses `typeof window === 'undefined'` to check. [`window` is defined in React Native](https://stackoverflow.com/questions/49911424/what-does-the-variable-window-represent-in-react-native), but may not be in test runners and other simulated environments.
+Please note that it uses `typeof window === 'undefined'` to check. [`window` is defined in React Native](https://stackoverflow.com/questions/49911424/what-does-the-variable-window-represent-in-react-native).<br>
+An exception is that `nodeNoop` is set to `false` when `process.env.NODE_ENV === 'test'` so that universal storage engines will not need extra configuration in tests.
 
 If you'd like to hydrate your store in Node (vs. in the browser, which is the standard usage), set `nodeNoop` to `false` and `storage` to a supported provider for Node.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ export const persist: IArgs = (name, store, options = {}) => {
 
   // no-op in node by default to support SSR out-of-the-box
   // require explicit opt-in to hydrate server-side
-  if (!nodeNoop) { nodeNoop = true }
+  // tests are generally run in Node, so don't require the option to be set
+  // in them, ensuring full backward-compatibility and easier testing for
+  // universal storage engines
+  if (!nodeNoop && process.env.NODE_ENV !== 'test') { nodeNoop = true }
   if (nodeNoop && typeof window === 'undefined') { return Promise.resolve() }
 
   // use AsyncLocalStorage by default or if window.localStorage was passed in

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,25 @@ export interface IOptions {
   storage?: any,
   jsonify?: boolean,
   readonly whitelist?: Array<string>,
-  readonly blacklist?: Array<string>
+  readonly blacklist?: Array<string>,
+  nodeNoop?: boolean
 }
 type StrToAnyMap = {[key: string]: any}
 
 export const persist: IArgs = (name, store, options = {}) => {
-  let {storage, jsonify, whitelist, blacklist} = options
+  let {storage, jsonify, whitelist, blacklist, nodeNoop} = options
 
-  if (typeof window.localStorage !== 'undefined' && (!storage || storage === window.localStorage)) {
+  // no-op in node by default to support SSR out-of-the-box
+  // require explicit opt-in to hydrate server-side
+  if (!nodeNoop) { nodeNoop = true }
+  if (nodeNoop && typeof window === 'undefined') { return Promise.resolve() }
+
+  // use AsyncLocalStorage by default or if window.localStorage was passed in
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.localStorage !== 'undefined' &&
+    (!storage || storage === window.localStorage)
+  ) {
     storage = AsyncLocalStorage
   }
   if (!storage) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ export const persist: IArgs = (name, store, options = {}) => {
   if (typeof window.localStorage !== 'undefined' && (!storage || storage === window.localStorage)) {
     storage = AsyncLocalStorage
   }
+  if (!storage) {
+    return Promise.reject('localStorage (the default storage engine) is not ' +
+      'supported in this environment. Please configure a different storage ' +
+      'engine via the `storage:` option.')
+  }
+
   if (!jsonify) { jsonify = true } // default to true like mobx-persist
   const whitelistDict = arrToDict(whitelist)
   const blacklistDict = arrToDict(blacklist)


### PR DESCRIPTION
- add a `nodeNoop` option that is `true` by default
  - generally folks do not want to hydrate their store during SSR, so
    no-op by default and require explicit opt-in to Node hydration
  - see #6 for discussion
- also throw an Error if localStorage isn't supported and no
  alternative storage provider has been given

(docs): add `nodeNoop` option and section on Node and SSR usage to
give more details and note possible gotchas

<hr>

Replaces #6 

After actually writing the docs for the gotchas, I'm on the fence about implementing this. The ramifications for test and other environments are not ideal either... Need to give it some more thought / consideration or discussion from more folks 💭 