### PR TITLE
Fix Support for Node and Add Docs for Node and SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ persist('some', someStore, {
       Any Storage Engine that has a Promise-style API similar to [`localForage`](https://github.com/localForage/localForage).
       The default is `localStorage`, which has a built-in adaptor to make it support Promises.
       For React Native, one may configure `AsyncStorage` instead.
+      <br>
+      Any of [`redux-persist`'s Storage Engines](https://github.com/rt2zz/redux-persist#storage-engines) should also be compatible with `mst-persist`.
     - **jsonify** *bool* Enables serialization as JSON (default: `true`).
     - **whitelist** *Array\<string\>* Only these keys will be persisted (defaults to all keys).
     - **blacklist** *Array\<string\>* These keys will not be persisted (defaults to all keys).

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ persist('some', someStore, {
 
 - returns a void Promise
 
+### Node and Server-Side Rendering (SSR) Usage
+
+Node environments are supported so long as you configure a Storage Engine that supports Node, such as [`redux-persist-node-storage`](https://github.com/pellejacobs/redux-persist-node-storage), [`redux-persist-cookie-storage`](https://github.com/abersager/redux-persist-cookie-storage), etc.
+This allows you to hydrate your store server-side.
+
+For SSR though, you may not want to hydrate your store server-side, so in that case you can call `persist` conditionally:
+
+```javascript
+if (typeof window !== 'undefined') { // window is undefined in Node
+  persist(...)
+}
+```
+
+With this conditional check, your store will only be hydrated client-side.
+
 ## Examples
 
 None yet, but can take a look at [agilgur5/react-native-manga-reader-app](https://github.com/agilgur5/react-native-manga-reader-app) which uses it in production.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ persist('some', someStore, {
   - **key** *string* The key of your storage engine that you want to persist to.
   - **store** *MST store* The store to be persisted.
   - **options** *object* Additional configuration options.
-    - **storage** *[localForage](https://github.com/localForage/localForage) / AsyncStorage / localStorage* [localForage](https://github.com/localForage/localForage)-style storage API. localStorage for Web (default), AsyncStorage for React Native.
+    - **storage** *[localForage](https://github.com/localForage/localForage) / AsyncStorage / localStorage*
+      Any Storage Engine that has a Promise-style API similar to [`localForage`](https://github.com/localForage/localForage).
+      The default is `localStorage`, which has a built-in adaptor to make it support Promises.
+      For React Native, one may configure `AsyncStorage` instead.
     - **jsonify** *bool* Enables serialization as JSON (default: `true`).
     - **whitelist** *Array\<string\>* Only these keys will be persisted (defaults to all keys).
     - **blacklist** *Array\<string\>* These keys will not be persisted (defaults to all keys).

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,12 @@ export const persist: IArgs = (name, store, options = {}) => {
   ) {
     storage = AsyncLocalStorage
   }
+  if (!storage) {
+    return Promise.reject('localStorage (the default storage engine) is not ' +
+      'supported in this environment. Please configure a different storage ' +
+      'engine via the `storage:` option.')
+  }
+
   if (!jsonify) { jsonify = true } // default to true like mobx-persist
   const whitelistDict = arrToDict(whitelist)
   const blacklistDict = arrToDict(blacklist)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,12 @@ type StrToAnyMap = {[key: string]: any}
 export const persist: IArgs = (name, store, options = {}) => {
   let {storage, jsonify, whitelist, blacklist} = options
 
-  if (typeof window.localStorage !== 'undefined' && (!storage || storage === window.localStorage)) {
+  // use AsyncLocalStorage by default (or if localStorage was passed in)
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.localStorage !== 'undefined' &&
+    (!storage || storage === window.localStorage)
+  ) {
     storage = AsyncLocalStorage
   }
   if (!jsonify) { jsonify = true } // default to true like mobx-persist


### PR DESCRIPTION
- (fix): do not error if 'window' is undefined
- (fix): throw an error if no storage is configured
- (docs): re-word storage section for clarity
- (docs): note redux-persist's Storage Engines compatibility
- (docs): add section on Node and SSR Usage

Replaces #6 and #9 and resolves #13 

The gotchas in #9 were a bit too confusing for me to really be okay with merging such functionality in. On top of that, once I discovered that `redux-persist`'s Storage Engines were also compatible with `mst-persist` (per #13), it meant that `mst-persist` could already support Node environments very easily, so I wouldn't want to hamper that type of usage by making it extremely unintuitive.
I think asking developers to put a conditional check in their own source code to handle SSR without server-side hydration is much simpler and less confusing, and therefore likely worthwhile even if it entails a bit more thought & work out-of-the-box.
