### PR TITLE
Add Transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ interface ITransformArgs {
 type StrToAnyMap = {[key: string]: any}
 ```
 
-As an example, one may see how [whitelists](https://github.com/agilgur5/mst-persist/blob/229fd2b1b472ea6a7912a5a06fa079a65e3ba6fa/src/whitelistTransform.ts#L7-L14) and [blacklists](https://github.com/agilgur5/mst-persist/blob/229fd2b1b472ea6a7912a5a06fa079a65e3ba6fa/src/blacklistTransform.ts#L7-L14) are implemented internally as transforms.
+As an example, one may see how [whitelists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/whitelistTransform.ts#L7-L12) and [blacklists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/blacklistTransform.ts#L7-L12) are implemented internally as transforms.
 
 #### Transform Ordering
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,35 @@ interface ITransformArgs {
 type StrToAnyMap = {[key: string]: any}
 ```
 
-As an example, one may see how [whitelists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/whitelistTransform.ts#L7-L12) and [blacklists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/blacklistTransform.ts#L7-L12) are implemented internally as transforms.
-Another example would be how the [transform test fixtures](https://github.com/agilgur5/mst-persist/blob/d3aa4476f92a087c882dccf8530a37096d8c64ed/test/fixtures.ts#L19-L34) are implemented internally.
+You can create your own transforms to serve a variety of needs.
+For example, if you wanted to only store the most recent posts:
+
+```typescript
+import { persist, ITransform } from 'mst-persist'
+
+import { FeedStore } from '../stores'
+
+const feedStore = FeedStore.create()
+
+const twoDaysAgo = new Date()
+twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+
+const onlyRecentPosts: ITransform = {
+  toStorage: (snapshot) => {
+    snapshot.posts = snapshot.posts.filter(
+      // note that a snapshotted Date is a string
+      post => new Date(post.date) > twoDaysAgo
+    )
+    return snapshot
+  }
+}
+
+persist('feed', feedStore, {
+  transforms: [onlyRecentPosts]
+})
+```
+
+For some other examples, one may see how [whitelists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/whitelistTransform.ts#L7-L12) and [blacklists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/blacklistTransform.ts#L7-L12) are implemented internally as transforms, as well as how the [transform test fixtures](https://github.com/agilgur5/mst-persist/blob/d3aa4476f92a087c882dccf8530a37096d8c64ed/test/fixtures.ts#L19-L34) are implemented internally.
 
 #### Transform Ordering
 
@@ -127,7 +154,7 @@ Can view the commit that implements it [here](https://github.com/agilgur5/react-
 ## How it works
 
 Basically a small wrapper around MST's [`onSnapshot` and `applySnapshot`](https://github.com/mobxjs/mobx-state-tree#snapshots).
-The source code is not much longer than this README, so [take a look under the hood](https://github.com/agilgur5/mst-persist/tree/master/src)! :)
+The source code is roughly the size of this README, so [take a look under the hood](https://github.com/agilgur5/mst-persist/tree/master/src)! :)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ type StrToAnyMap = {[key: string]: any}
 ```
 
 As an example, one may see how [whitelists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/whitelistTransform.ts#L7-L12) and [blacklists](https://github.com/agilgur5/mst-persist/blob/9ba76aaf455f42e249dc855d66349351148a17da/src/blacklistTransform.ts#L7-L12) are implemented internally as transforms.
+Another example would be how the [transform test fixtures](https://github.com/agilgur5/mst-persist/blob/d3aa4476f92a087c882dccf8530a37096d8c64ed/test/fixtures.ts#L19-L34) are implemented internally.
 
 #### Transform Ordering
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Can view the commit that implements it [here](https://github.com/agilgur5/react-
 
 ## How it works
 
-Basically just a small wrapper around MST's [`onSnapshot` and `applySnapshot`](https://github.com/mobxjs/mobx-state-tree#snapshots).
-The source code is currently shorter than this README, so [take a look under the hood](https://github.com/agilgur5/mst-persist/tree/master/src)! :)
+Basically a small wrapper around MST's [`onSnapshot` and `applySnapshot`](https://github.com/mobxjs/mobx-state-tree#snapshots).
+The source code is not much longer than this README, so [take a look under the hood](https://github.com/agilgur5/mst-persist/tree/master/src)! :)
 
 ## Credits
 

--- a/src/transforms/blacklist.ts
+++ b/src/transforms/blacklist.ts
@@ -1,0 +1,14 @@
+import { ITransform, arrToDict } from './utils'
+
+export function blacklistKeys (blacklist?: Array<string>): ITransform {
+  const blacklistDict = arrToDict(blacklist)
+
+  return {toStorage: function blacklistTransform (snapshot) {
+    Object.keys(snapshot).forEach((key) => {
+      if (blacklist && blacklistDict[key]) {
+        delete snapshot[key]
+      }
+    })
+    return snapshot
+  }}
+}

--- a/src/transforms/blacklist.ts
+++ b/src/transforms/blacklist.ts
@@ -1,11 +1,9 @@
 import { ITransform, arrToDict } from './utils'
 
-export function blacklistKeys (blacklist?: Array<string>): ITransform {
+export function blacklistKeys (blacklist: Array<string>): ITransform {
   const blacklistDict = arrToDict(blacklist)
 
   return {toStorage: function blacklistTransform (snapshot) {
-    if (!blacklist) { return snapshot }
-
     Object.keys(snapshot).forEach((key) => {
       if (blacklistDict[key]) { delete snapshot[key] }
     })

--- a/src/transforms/blacklist.ts
+++ b/src/transforms/blacklist.ts
@@ -4,10 +4,10 @@ export function blacklistKeys (blacklist?: Array<string>): ITransform {
   const blacklistDict = arrToDict(blacklist)
 
   return {toStorage: function blacklistTransform (snapshot) {
+    if (!blacklist) { return snapshot }
+
     Object.keys(snapshot).forEach((key) => {
-      if (blacklist && blacklistDict[key]) {
-        delete snapshot[key]
-      }
+      if (blacklistDict[key]) { delete snapshot[key] }
     })
     return snapshot
   }}

--- a/src/transforms/index.ts
+++ b/src/transforms/index.ts
@@ -1,0 +1,4 @@
+export { ITransform, ITransformArgs } from './utils'
+
+export { whitelistKeys } from './whitelist'
+export { blacklistKeys } from './blacklist'

--- a/src/transforms/utils.ts
+++ b/src/transforms/utils.ts
@@ -1,0 +1,19 @@
+import { StrToAnyMap } from '../utils'
+
+export interface ITransform {
+  readonly toStorage?: ITransformArgs,
+  readonly fromStorage?: ITransformArgs
+}
+export interface ITransformArgs {
+  (snapshot: StrToAnyMap): StrToAnyMap
+}
+
+type StrToBoolMap = {[key: string]: boolean}
+
+export function arrToDict (arr?: Array<string>): StrToBoolMap {
+  if (!arr) { return {} }
+  return arr.reduce((dict: StrToBoolMap, elem) => {
+    dict[elem] = true
+    return dict
+  }, {})
+}

--- a/src/transforms/utils.ts
+++ b/src/transforms/utils.ts
@@ -10,8 +10,7 @@ export interface ITransformArgs {
 
 type StrToBoolMap = {[key: string]: boolean}
 
-export function arrToDict (arr?: Array<string>): StrToBoolMap {
-  if (!arr) { return {} }
+export function arrToDict (arr: Array<string>): StrToBoolMap {
   return arr.reduce((dict: StrToBoolMap, elem) => {
     dict[elem] = true
     return dict

--- a/src/transforms/whitelist.ts
+++ b/src/transforms/whitelist.ts
@@ -4,10 +4,10 @@ export function whitelistKeys (whitelist?: Array<string>): ITransform {
   const whitelistDict = arrToDict(whitelist)
 
   return {toStorage: function whitelistTransform (snapshot) {
+    if (!whitelist) { return snapshot }
+
     Object.keys(snapshot).forEach((key) => {
-      if (whitelist && !whitelistDict[key]) {
-        delete snapshot[key]
-      }
+      if (!whitelistDict[key]) { delete snapshot[key] }
     })
     return snapshot
   }}

--- a/src/transforms/whitelist.ts
+++ b/src/transforms/whitelist.ts
@@ -1,0 +1,14 @@
+import { ITransform, arrToDict } from './utils'
+
+export function whitelistKeys (whitelist?: Array<string>): ITransform {
+  const whitelistDict = arrToDict(whitelist)
+
+  return {toStorage: function whitelistTransform (snapshot) {
+    Object.keys(snapshot).forEach((key) => {
+      if (whitelist && !whitelistDict[key]) {
+        delete snapshot[key]
+      }
+    })
+    return snapshot
+  }}
+}

--- a/src/transforms/whitelist.ts
+++ b/src/transforms/whitelist.ts
@@ -1,11 +1,9 @@
 import { ITransform, arrToDict } from './utils'
 
-export function whitelistKeys (whitelist?: Array<string>): ITransform {
+export function whitelistKeys (whitelist: Array<string>): ITransform {
   const whitelistDict = arrToDict(whitelist)
 
   return {toStorage: function whitelistTransform (snapshot) {
-    if (!whitelist) { return snapshot }
-
     Object.keys(snapshot).forEach((key) => {
       if (!whitelistDict[key]) { delete snapshot[key] }
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export type StrToAnyMap = {[key: string]: any}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,5 +1,7 @@
 import { types } from 'mobx-state-tree'
 
+import { ITransform, ITransformArgs } from '../src/index'
+
 export const UserStoreF = types.model('UserStore', {
   name: 'John Doe',
   age: 32
@@ -12,4 +14,20 @@ export const UserStoreF = types.model('UserStore', {
 export const persistedDataF = {
   name: 'Persisted Name',
   age: 35
+}
+
+function changeName (name: string) {
+  const changeNameTransform: ITransformArgs = function (snapshot) {
+    snapshot.name = name
+    return snapshot
+  }
+  return changeNameTransform
+}
+
+export function storeNameAsF (name: string): ITransform {
+  return {toStorage: changeName(name)}
+}
+
+export function retrieveNameAsF (name: string): ITransform {
+  return {fromStorage: changeName(name)}
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,11 +2,15 @@
 import { getSnapshot } from 'mobx-state-tree'
 
 import { persist } from '../src/index'
-import { UserStoreF, persistedDataF } from './fixtures'
+import { UserStoreF, persistedDataF, storeNameAsF, retrieveNameAsF } from './fixtures'
 
 function getItem(key: string) {
   const item = window.localStorage.getItem(key)
   return item ? JSON.parse(item) : null // can only parse strings
+}
+
+function setItem(key: string, value: object) {
+  return window.localStorage.setItem(key, JSON.stringify(value))
 }
 
 describe('basic persist functionality', () => {
@@ -28,15 +32,16 @@ describe('basic persist functionality', () => {
   })
 
   it('should load persisted data', async () => {
-    window.localStorage.setItem('user', JSON.stringify(persistedDataF))
+    setItem('user', persistedDataF)
 
     const user = UserStoreF.create()
     await persist('user', user)
+
     expect(getSnapshot(user)).toStrictEqual(persistedDataF)
   })
 })
 
-describe('persist options', () => {
+describe('basic persist options', () => {
   beforeEach(() => window.localStorage.clear())
 
   it('shouldn\'t jsonify', async () => {
@@ -72,5 +77,32 @@ describe('persist options', () => {
     const snapshot = { ...getSnapshot(user) } // need to shallow clone as otherwise properties are non-configurable (https://github.com/agilgur5/mst-persist/pull/21#discussion_r348105595)
     delete snapshot['age']
     expect(getItem('user')).toStrictEqual(snapshot)
+  })
+})
+
+describe('transforms', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('should apply toStorage transforms in order', async () => {
+    const user = UserStoreF.create()
+    await persist('user', user, {
+      transforms: [storeNameAsF('Jack'), storeNameAsF('Joe')]
+    })
+
+    user.changeName('Not Joe') // fire action to trigger onSnapshot
+    expect(getItem('user').name).toBe('Joe')
+  })
+
+  it('should apply fromStorage transforms in reverse order', async () => {
+    const persistedData = {...persistedDataF}
+    persistedData.name = 'Not Joe'
+    setItem('user', persistedData)
+
+    const user = UserStoreF.create()
+    await persist('user', user, {
+      transforms: [retrieveNameAsF('Joe'), retrieveNameAsF('Jack')]
+    })
+
+    expect(getSnapshot(user).name).toBe('Joe')
   })
 })


### PR DESCRIPTION
- object with `toStorage` and `fromStorage` functions
  - `toStorage` is called after removing whitelist and blacklists and
    before serializing to JSON
  - `fromStorage` is called after deserializing from JSON
- refactor whitelist and blacklist into transforms

## Review Notes

- [x] ~`transforms` needs to have a default arg, even if it's later guaranteed to not be `undefined`, so the `|| []`is currently redundant. This might be related to https://github.com/microsoft/TypeScript/issues/29642.~
  - In the process of writing a comment for that issue, I realized that behavior is probably correct / expected. As the `onSnapshot` callback is async, `transforms` _could_ be set to `undefined` before it runs. While it's not in our code, the typings allow that, vs. having a default ensures it can't be set to undefined (it's no longer optional/`?`). See also my [playground link](http://www.typescriptlang.org/play/#code/GYVwdgxgLglg9mABAIxAczQTwBRQE4CGYAzsHHgLbED8AXIsfjGGgNoC6AlIgN6ID0-RAQAmI5mmGIRAU2AEQAGyiI4wRB0RoZUYojwwRq9TLx5yxAFCIbifEVLkqiALwbrtzwDofuQiTJKPQAfYI0uASFiAAs4JSMwGQA3UxQZRHBZYGYZEQ8bdkt8u39HIK9AgFECCGjsbG4XAD5eRABfbkFEMDhEU3M8Is8ABXMKGGIZLzwZYjhFFIavKGiZMHrGlp5iz3sAp2IK8mrajdct9s6haII9fvIAGmlZgAcYKHTEiFniAgNFTCqCAQEBmCTCYAfQaeDqWNqWIA).
- [x] Recursive import of `ITransform` from `./index` seems non-optimal
  - Created a `transforms/` directory and moved transforms there. In the future, would like users to import from `mst-persist/transforms`, so it might make sense to _only_ export `ITransform` etc from there, and not from `mst-persist`. Would have to figure out how to make an alias with tsdx.
- [x] ~The new transform docs are quite verbose / wordy. I think the interface code block and the ordering visual explain much better than the words (though I am not sure if they are accessible), so maybe it make sense to remove all the verbal/words description. The words might actually make it more confusing than just the code block and visual alone.~
  - Actually, upon looking at it again at a later date, I do think the verbal description provides some extra details that are helpful. Like the Transform portion links to the MST snapshot docs and describes the object as "snapshot-like". The Ordering portion describes what the functions listed in the text actually do (which may not be so clear to beginners).
- [x] [Tests](https://github.com/agilgur5/mst-persist/issues/4) would be very useful to ensure there are no regressions with this. And as we add more to the API and proceed to thinking about migrations, it becomes even more important that there aren't regressions. As bugs here could potentially cause users to lose data, tests are particularly critical for this library.
  - As of #21, `mst-persist` now has tests and 100% code coverage. ~This PR now just needs to be rebased and add some tests.~
    - Done, tests added here.
- [x] Need to write up an RFC for "Transforms & Migrations (& Plugins??)" to consider how future uses of transforms will look like so we make more iterations now instead of later when they will be breaking changes.
  - Done, see #23 

## Trade-off Analysis

Went through a few iterations of this API and source code. Making whitelists and blacklists internal transforms gave me a bit of hands-on usage as I was building it too, which was good. Thinking of removing the `whitelist` and `blacklist` config options in the next major/breaking version and just telling users to use the transform as it simplifies the config options API and makes the ordering explicit.
I considered adding a `transformOrder` config option that (after some considerations) would just be an array of enums/strings with a default of `['whitelist', 'blacklist', 'customs']` for full control of the built-in options, but honestly just telling users to use them as transforms themselves is much simpler and less confusing.

Used `toStorage` and `fromStorage` as it makes very explicit the directionality, unlike [`redux-persist`'s "inbound" and "outbound"](https://github.com/rt2zz/redux-persist#transforms) which are very confusing / ambiguous imo (outbound from what??).
I decided to use those names a while ago, but when I was recently looking up the rationale for `redux-persist`'s transform design in PRs and issues, I also found [this issue](https://github.com/rt2zz/redux-persist/issues/437) asking for the naming to be `toStorage` and `fromStorage` as well (that probably would've been breaking at that point in time though). Here's [another comment](https://github.com/rt2zz/redux-persist/pull/188#issuecomment-252004427) responding to a very confused PR about the same naming issue. These are just two instances of public confusion I found, there's probably more public instances, and far more private instances.

I also don't believe we need to use a `createTransform` function like `redux-persist` has, which adds more imports and I think makes the API more weighty. `redux-persist` has some different constraints specific to `redux`, namely immutability and reducers to deal with. Some of the naming concerns seem due to reducer usage as well.

Considered using [`reduce` and `reduceRight` like `redux-persist`](https://github.com/rt2zz/redux-persist/blob/c3841f2fc56adf30a87cd61f7d2315146048079e/src/getStoredState.js#L31), but decided against limiting it that way or making it _seem_ more immutable (it's not and doesn't have to be). Should still return a `snapshot`-like object right now, but could in theory remove that in the future or add ability to return other things. I think focusing on the snapshot makes it narrow and easier to understand for now. Reducing it does make it more explicit that one transform's output is another's input. 🤷‍♂ guess it's probably not that big a difference which to use.

Attempted writing the JSON (de)serialization as a transform too, but it doesn't fit the Transform Interface as it's to and from a string, and because the deserialization can return early and bail if falsey. The latter is particularly weird and accounting for it would make the interface quite confusing (unless we just threw/caught an error?).

## Future Work

It might make sense to make JSON (de)serialization and other features available as "plugins", with "transforms" being one type of plugin. This would allow for full control of ordering of the _entire_ internals and basically inverts the paradigm for full flexibility (kind of like how webpack does it). Though at that point, the source code isn't much beyond `onSnapshot` and `applySnapshot`, though we do add a lot of built-in functionality and smart defaults.

See #23