### PR TITLE
(hotfix): jsonify shouldn't set false to true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface IOptions {
 type StrToAnyMap = {[key: string]: any}
 
 export const persist: IArgs = (name, store, options = {}) => {
-  let {storage, jsonify, whitelist, blacklist} = options
+  let {storage, jsonify = true, whitelist, blacklist} = options
 
   // use AsyncLocalStorage by default (or if localStorage was passed in)
   if (
@@ -30,7 +30,6 @@ export const persist: IArgs = (name, store, options = {}) => {
       'engine via the `storage:` option.')
   }
 
-  if (!jsonify) { jsonify = true } // default to true like mobx-persist
   const whitelistDict = arrToDict(whitelist)
   const blacklistDict = arrToDict(blacklist)
 


### PR DESCRIPTION
- meant to use the previous code as an alternative to using a default
  arg, but `!jsonify` detects false (etc), not just undefined
  - switched to just using a default arg, which was what I originally
    used before moving defaults outside of the destructuring
  - alternative is to check `typeof jsonify === 'undefined'` instead
  - default args seem to provide better typings in my experience, so
    stick to that for now

Fixes #17 . Would really like to get #4 done before releasing this for that extra confidence that it actually works though.