### PR TITLE
(fix): resolve AsyncLocalStorage Illegal Invocation errors

### DIFF
--- a/src/asyncLocalStorage.ts
+++ b/src/asyncLocalStorage.ts
@@ -6,17 +6,18 @@ interface IAsyncLocalStorage {
 }
 
 export const AsyncLocalStorage: IAsyncLocalStorage = {
+  // must use wrapper functions when passing localStorage functions (https://github.com/agilgur5/mst-persist/issues/18)
   clear () {
-    return callWithPromise(window.localStorage.clear)
+    return callWithPromise(() => window.localStorage.clear())
   },
   getItem (key) {
-    return callWithPromise(window.localStorage.getItem, key)
+    return callWithPromise(() => window.localStorage.getItem(key))
   },
   removeItem (key) {
-    return callWithPromise(window.localStorage.removeItem, key)
+    return callWithPromise(() => window.localStorage.removeItem(key))
   },
   setItem (key, value) {
-    return callWithPromise(window.localStorage.setItem, key, value)
+    return callWithPromise(() => window.localStorage.setItem(key, value))
   }
 }
 


### PR DESCRIPTION
- I (and apparently most mst-persist users) don't use localStorage, so
  this went undetected for a while until someone reported a bug
  - and I finally hit upon it myself when adding tests shortly after,
    which added a solid reproduction as well as a blocker on it

- it made localStorage unusable as all of AsyncLocalStorage's calls
  would give Illegal Invocation errors
  - see https://stackoverflow.com/q/41126149/3431180 for more details
    on this error
    - using .call did not work, not on
      callWithPromise.call(window, ...) nor func.call(window, ...args)
    - similarly window.localStorage.func.bind(window) did not work
    - so instead used wrapper functions as an alternative that didn't
      feel too convoluted
      - using window.localStorage[funcKey] in callWithPromise did not
        quite feel right, wrapper functions felt better

Fixes #18 . Split out of #21 -- was reproduced while creating tests and is needed for tests to pass as well. The fix for this was tested locally against #21, so can be confident it works.