### PR TITLE
v0.1.3 -- (env/deps): use agilgur5/tsdx fork for esModuleInterop etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 ### tsdx ###
 
 dist/
-.rts2_cache_cjs
-.rts2_cache_esm
-.rts2_cache_umd
 coverage/
 
 ### Node ###

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- releases / versioning -->
 [![package-json](https://img.shields.io/github/package-json/v/agilgur5/mst-persist.svg)](https://npmjs.org/package/mst-persist)
 [![releases](https://img.shields.io/github/tag-pre/agilgur5/mst-persist.svg)](https://github.com/agilgur5/mst-persist/releases)
-[![commits](https://img.shields.io/github/commits-since/agilgur5/mst-persist/v0.1.2.svg)](https://github.com/agilgur5/mst-persist/commits/master)
+[![commits](https://img.shields.io/github/commits-since/agilgur5/mst-persist/v0.1.3.svg)](https://github.com/agilgur5/mst-persist/commits/master)
 <br><!-- downloads -->
 [![dt](https://img.shields.io/npm/dt/mst-persist.svg)](https://npmjs.org/package/mst-persist)
 [![dy](https://img.shields.io/npm/dy/mst-persist.svg)](https://npmjs.org/package/mst-persist)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9202,9 +9202,8 @@
       }
     },
     "tsdx": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/tsdx/-/tsdx-0.11.0.tgz",
-      "integrity": "sha512-BZNelFql6MiSgaoJN45XHjW2NyOk9DaD6Ai94c8DJy8QsadOm3OQRJVJU8rDgYRcIeWok90A3BBB2moZgui22Q==",
+      "version": "github:agilgur5/tsdx#4adb711dd865ad098d1f15edf7c615f85e1c5315",
+      "from": "github:agilgur5/tsdx#dist",
       "dev": true,
       "requires": {
         "@babel/core": "^7.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-persist",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-persist",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Persist and hydrate MobX-state-tree stores",
   "main": "dist/index.js",
   "module": "dist/mst-persist.esm.js",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "^24.0.23",
     "mobx": "^5.11.0",
     "mobx-state-tree": "^3.14.0",
-    "tsdx": "^0.11.0",
+    "tsdx": "github:agilgur5/tsdx#dist",
     "typescript": "^3.5.2"
   }
 }


### PR DESCRIPTION
- this uses my fork which merged my commit that fixes the missing
  __esModule in CJS build output
  - which has been an issue in this library since adopting tsdx, as
    that's still an undocumented bug in tsdx
  - until this fix is merged and released in the root library, will
    be using this fork

- it also has my recently merged commit that changes the cacheRoot to
  ./node_modules/.cache/ instead of ./rts2_cache_* directories
  - can remove them from gitignore and they no longer clutter app root

Fixes #12 by using my fork as I'm not sure when https://github.com/jaredpalmer/tsdx/pull/327 will be merged (it has yet to be reviewed)