### PR TITLE
ci: migrate to GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+on: [push]
+jobs:
+  ci:
+    name: CI - Node ${{ matrix.node-version }}, ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x] # LTS Node: https://nodejs.org/en/about/releases/
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install
+      run: npm ci
+
+    - name: Typecheck
+      run: npm run tsc
+    # TODO: add when ts-standard linting is configured
+    # - name: Lint
+    #   run: npm run lint
+    - name: Build
+      run: npm run build
+
+    - name: Test w/ coverage report
+      run: npm run test:coverage
+    - name: Upload coverage report to Codecov
+      uses: codecov/codecov-action@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-# default is the very old 0.10.48; match local version instead
-node_js: '10.16.0'
-
-script: npm test -- --coverage
-after_script:
-  # upload coverage reports to CodeCov
-  - bash <(curl -s https://codecov.io/bash)
-  - npm run test:pub

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![dw](https://img.shields.io/npm/dw/mst-persist.svg)](https://npmjs.org/package/mst-persist)
 <br><!-- status / activity -->
 [![typings](https://img.shields.io/npm/types/mst-persist.svg)](https://github.com/agilgur5/mst-persist/blob/master/src/index.ts)
-[![build status](https://img.shields.io/travis/agilgur5/mst-persist/master.svg)](https://travis-ci.org/agilgur5/mst-persist)
+[![build status](https://img.shields.io/github/actions/workflow/status/agilgur5/mst-persist/ci.yml?branch=main)](https://github.com/agilgur5/mst-persist/actions/workflows/ci.yml?query=branch%3Amain)
 [![code coverage](https://img.shields.io/codecov/c/gh/agilgur5/mst-persist/master.svg)](https://codecov.io/gh/agilgur5/mst-persist)
 <br>
 [![NPM](https://nodei.co/npm/mst-persist.png?downloads=true&downloadRank=true&stars=true)](https://npmjs.org/package/mst-persist)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
+    "tsc": "tsc --noEmit",
     "test": "tsdx test",
+    "test:coverage": "tsdx test --coverage",
     "test:pub": "npm run build && npm pack",
     "pub": "npm run build && npm publish",
     "changelog": "changelog-maker"


### PR DESCRIPTION
## Summary

Migrate over to GH Actions from Travis
- More or less copies my previous work in https://github.com/agilgur5/react-signature-canvas/pull/84 and https://github.com/agilgur5/react-signature-canvas/pull/85

## Details

- mostly duplicate what I have in [react-signature-canvas](https://github.com/agilgur5/react-signature-canvas/blob/main/.github/workflows/ci.yml)
  - update LTS Node versions to 18.x and 20.x
  - comment out linting step for now as `ts-standard` hasn't been configured in this repo

- add `tsc` and `test:coverage` scripts for CI
  - had to specify `--noEmit` for now, the whole build system will need to be revamped later

- replace Travis badge with GH Actions badge
  - also fixed the badge error: https://github.com/badges/shields/issues/8671