### PR TITLE
docs: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@
 [![dm](https://img.shields.io/npm/dm/mst-persist.svg)](https://npmjs.org/package/mst-persist)
 [![dw](https://img.shields.io/npm/dw/mst-persist.svg)](https://npmjs.org/package/mst-persist)
 <br><!-- status / activity -->
-[![typings](https://img.shields.io/npm/types/mst-persist.svg)](https://github.com/agilgur5/mst-persist/blob/master/src/index.ts)
+[![typings](https://img.shields.io/npm/types/mst-persist.svg)](src/index.ts)
 [![build status](https://img.shields.io/github/actions/workflow/status/agilgur5/mst-persist/ci.yml?branch=main)](https://github.com/agilgur5/mst-persist/actions/workflows/ci.yml?query=branch%3Amain)
 [![code coverage](https://img.shields.io/codecov/c/gh/agilgur5/mst-persist/master.svg)](https://codecov.io/gh/agilgur5/mst-persist)
-<br>
-[![NPM](https://nodei.co/npm/mst-persist.png?downloads=true&downloadRank=true&stars=true)](https://npmjs.org/package/mst-persist)
 
 Persist and hydrate [MobX-state-tree](https://github.com/mobxjs/mobx-state-tree) stores.
 
 ## Installation
 
-`npm i -S mst-persist`
+```sh
+npm i -S mst-persist
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Update badges a tiny bit to be more consistent with what I use today

## Details

- remove old `nodei.co` badge
  - doesn't always load and isn't very useful anymore
  - removing it from all of my NPM projects

- simplify typings badge to use a relative link
  - no need to specify branch name or full repo name

- also change Installation to a codeblock instead of just backticks
  - easier to read as a block and easier to copy (full horizontal length)
  - and more consistent too