### PR TITLE
test: add new suite for complex types, starting with arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ With this conditional check, your store will only be hydrated client-side.
 None yet, but can take a look at [agilgur5/react-native-manga-reader-app](https://github.com/agilgur5/react-native-manga-reader-app) which uses it in production.
 Can view the commit that implements it [here](https://github.com/agilgur5/react-native-manga-reader-app/pull/2/commits/286725f417d321f25d16ee3858b0e7e6b7886e77).
 
+Can also view some of the internal [tests](test/).
+
 ## How it works
 
 Basically just a small wrapper around MST's [`onSnapshot` and `applySnapshot`](https://github.com/mobxjs/mobx-state-tree#snapshots).

--- a/test/complex.spec.ts
+++ b/test/complex.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'jest-without-globals'
+import { getSnapshot } from 'mobx-state-tree'
+
+import { persist } from '../src/index'
+
+import { getItem } from './helpers'
+import { ComplexUserStoreF, persistedComplexUserDataF } from './fixtures'
+
+describe('persist complex types', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('should persist an array', async () => {
+    const user = ComplexUserStoreF.create()
+    await persist('user', user)
+
+    user.addDog('Shadow') // fire action to trigger onSnapshot
+    expect(user.dogs).toStrictEqual(['Shadow'])
+    expect(getItem('user')).toStrictEqual(getSnapshot(user))
+  })
+
+  it('should persist a whitelisted array', async () => {
+    const user = ComplexUserStoreF.create()
+    await persist('user', user, {
+      whitelist: ['name', 'dogs']
+    })
+
+    user.addDog('Shadow') // fire action to trigger onSnapshot
+    expect(user.dogs).toStrictEqual(['Shadow'])
+    expect(getItem('user')).toStrictEqual(getSnapshot(user))
+  })
+
+  it('should load a persisted array', async () => {
+    window.localStorage.setItem('user', JSON.stringify(persistedComplexUserDataF))
+
+    const user = ComplexUserStoreF.create()
+    await persist('user', user)
+    expect(getSnapshot(user)).toStrictEqual(persistedComplexUserDataF)
+  })
+})

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -10,8 +10,22 @@ export const UserStoreF = types.model('UserStore', {
   }
 }))
 
-export const persistedDataF = {
+export const persistedUserDataF = {
   name: 'Persisted Name',
   age: 35,
   hasDogs: false,
+}
+
+export const ComplexUserStoreF = types.model('ComplexUserStore', {
+  name: 'John Doe',
+  dogs: types.array(types.string),
+}).actions((self) => ({
+  addDog(dog: string) {
+    self.dogs.push(dog)
+  }
+}))
+
+export const persistedComplexUserDataF = {
+  name: 'John Doe',
+  dogs: ['Shadow', 'Sparky'],
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,4 @@
+export function getItem(key: string) {
+  const item = window.localStorage.getItem(key)
+  return item ? JSON.parse(item) : null // can only parse strings
+}

--- a/test/index.node.spec.ts
+++ b/test/index.node.spec.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'jest-without-globals'
 
 import { persist } from '../src/index'
+
 import { UserStoreF } from './fixtures'
 
 describe('node usage', () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,14 +2,11 @@ import { describe, it, expect, beforeEach } from 'jest-without-globals'
 import { getSnapshot } from 'mobx-state-tree'
 
 import { persist } from '../src/index'
-import { UserStoreF, persistedDataF } from './fixtures'
 
-function getItem(key: string) {
-  const item = window.localStorage.getItem(key)
-  return item ? JSON.parse(item) : null // can only parse strings
-}
+import { getItem } from './helpers'
+import { UserStoreF, persistedUserDataF } from './fixtures'
 
-describe('basic persist functionality', () => {
+describe('basic persist functionality with primitves', () => {
   beforeEach(() => window.localStorage.clear())
 
   it('should persist nothing if no actions are used', async () => {
@@ -24,15 +21,16 @@ describe('basic persist functionality', () => {
     await persist('user', user)
 
     user.changeName('Joe') // fire action to trigger onSnapshot
+    expect(user.name).toBe('Joe')
     expect(getItem('user')).toStrictEqual(getSnapshot(user))
   })
 
   it('should load persisted data', async () => {
-    window.localStorage.setItem('user', JSON.stringify(persistedDataF))
+    window.localStorage.setItem('user', JSON.stringify(persistedUserDataF))
 
     const user = UserStoreF.create()
     await persist('user', user)
-    expect(getSnapshot(user)).toStrictEqual(persistedDataF)
+    expect(getSnapshot(user)).toStrictEqual(persistedUserDataF)
   })
 })
 
@@ -59,6 +57,7 @@ describe('persist options', () => {
     user.changeName('Joe') // fire action to trigger onSnapshot
     const snapshot = { ...getSnapshot(user) } // need to shallow clone as otherwise properties are non-configurable (https://github.com/agilgur5/mst-persist/pull/21#discussion_r348105595)
     delete snapshot['age']
+    expect(snapshot.name).toBe('Joe')
     expect(getItem('user')).toStrictEqual(snapshot)
   })
 
@@ -71,6 +70,7 @@ describe('persist options', () => {
     user.changeName('Joe') // fire action to trigger onSnapshot
     const snapshot = { ...getSnapshot(user) } // need to shallow clone as otherwise properties are non-configurable (https://github.com/agilgur5/mst-persist/pull/21#discussion_r348105595)
     delete snapshot['age']
+    expect(snapshot.name).toBe('Joe')
     expect(getItem('user')).toStrictEqual(snapshot)
   })
 })


### PR DESCRIPTION
## Summary

Start testing complex types, create a test for arrays

## Details

### Main Changes

- add `test/complex.spec.ts`
- move `getItem` into `test/helpers.ts` as it's used by both
  - add a new line to separate test helper file imports from source code imports
- distinguish fixture naming a bit to handle two test stores now
- specify that the basic test is for "primitives"

- used a separate test suite / test file as the basic one may continue to grow (e.g. with more options) and the complex one will definitely grow (e.g. with maps)
  - I try not to have overly bulky files

### Secondary Changes

- add some secondary `expect`s to double-check that actions worked
- docs: mention the `test` directory as example usage

## Future Work

1. Test `types.map`
1. Test nested models (possibly as a new test suite)

## References

Confirms that I can't reproduce #29 